### PR TITLE
fix: ParseURL() slice bounds out of range

### DIFF
--- a/infoscan/service/Crawler/Processor/data_process.go
+++ b/infoscan/service/Crawler/Processor/data_process.go
@@ -21,9 +21,10 @@ var (
 )
 
 /*
-	将html结构中的url数据进行处理：
-		1.提取url数据
-		2.去除不同域
+将html结构中的url数据进行处理：
+
+	1.提取url数据
+	2.去除不同域
 */
 func Findurl(body []byte, Murl string) [][]*url.URL {
 	data := pkg.Bytes2String(body)
@@ -166,26 +167,11 @@ func HtmlFindUrlpressor(ulist []string, iurl string) [][]*url.URL {
 
 // ParseURL 从URL中提取域名
 func ParseURL(url string) string {
-	var domain string
-	//"https://www.baidu.com"
-	if strings.Contains(url, "http") || strings.Contains(url, "https") {
-		frontSep := url[strings.Index(url, ":")+3:]
-		if !strings.Contains(frontSep, "/") {
-			domain = frontSep
-		} else {
-			domain = frontSep[:strings.Index(frontSep, "/")]
-		}
-		//"//www.baidu.com/
-	} else {
-		frontSep := url[strings.Index(url, "/")+2:]
-		if !strings.Contains(frontSep, "/") {
-			domain = frontSep
-		} else {
-			domain = frontSep[:strings.Index(frontSep, "/")]
-		}
+	u, err := url.Parse(url)
+	if err != nil {
+		return ""
 	}
-
-	return domain
+	return u.Hostname()
 }
 
 func DecodeChars(s string) string {


### PR DESCRIPTION
ParseURL 在处理URL时出现数组越界错误，原始代码假定了“:”, “//” 是存在的，当这两个字符不存在的时候，就会触发slice bounds out of range 错误。